### PR TITLE
chore: add nanoarrow

### DIFF
--- a/packages/nanoarrow
+++ b/packages/nanoarrow
@@ -1,0 +1,6 @@
+{
+  "package": "nanoarrow",
+  "url": "https://github.com/apache/arrow-nanoarrow",
+  "subdir": "r",
+  "branch": "*release"
+}


### PR DESCRIPTION
The `nanoarrow` package is worth including here because it is an important package that serves as a hub for zero-copy exchange of Apache Arrow format data between packages.