### PR TITLE
chore: add rlang

### DIFF
--- a/packages/rlang
+++ b/packages/rlang
@@ -1,0 +1,1 @@
+https://github.com/r-lib/rlang


### PR DESCRIPTION
Since rlang is an important package that is a dependency of so many packages, it is worthwhile to be able to install it from here.