### PR TITLE
Deregister INLA (for now)

### DIFF
--- a/packages/INLA
+++ b/packages/INLA
@@ -1,1 +1,0 @@
-https://github.com/inbo/INLA


### PR DESCRIPTION
I originally registered INLA early on, in hopes it would benefit the Bayesian Statistics community. But the R-multiverse link to the source code repository is incorrect, the [correct link](https://github.com/hrue/r-inla) does not have any releases, and the promised `LICENSE` file ([`License: MIT + file LICENSE`](https://github.com/hrue/r-inla/blob/devel/rinla/DESCRIPTION#L74) in the `DESCRIPTION`) is missing. As mentioned in https://github.com/r-universe-org/help/issues/606, it's probably best to deregister the package for now, then contact the author about possibly registering later on.