### PR TITLE
chore: freeze adbcbigquery to the last release

### DIFF
--- a/packages/adbcbigquery
+++ b/packages/adbcbigquery
@@ -2,5 +2,5 @@
   "package": "adbcbigquery",
   "url": "https://github.com/apache/arrow-adbc",
   "subdir": "r/adbcbigquery",
-  "branch": "*release"
+  "branch": "apache-arrow-adbc-23"
 }


### PR DESCRIPTION
Related to r-multiverse/help#174

The latest ADBC ​​BigQuery driver release has shifted from language-specific packages (such as R) to distributing a shared ADBC ​​driver library.
However, since some people may still want to install and use R packages from R-multiverse, I think it's worth pinning the final release to continue supporting installation from R-multiverse.