### PR TITLE
Add ggsegverse core packages

### DIFF
--- a/packages/ggseg
+++ b/packages/ggseg
@@ -1,0 +1,1 @@
+https://github.com/ggsegverse/ggseg

--- a/packages/ggseg.formats
+++ b/packages/ggseg.formats
@@ -1,0 +1,1 @@
+https://github.com/ggsegverse/ggseg.formats

--- a/packages/ggseg.meshes
+++ b/packages/ggseg.meshes
@@ -1,0 +1,1 @@
+https://github.com/ggsegverse/ggseg.meshes

--- a/packages/ggseg3d
+++ b/packages/ggseg3d
@@ -1,0 +1,1 @@
+https://github.com/ggsegverse/ggseg3d


### PR DESCRIPTION
## Summary

Adds the four core packages from the [ggsegverse](https://ggsegverse.r-universe.dev) brain atlas visualization ecosystem:

| Package | GitHub | Description |
|---------|--------|-------------|
| `ggseg.formats` | [ggsegverse/ggseg.formats](https://github.com/ggsegverse/ggseg.formats) | Unified `brain_atlas` class, atlas validation, FreeSurfer I/O |
| `ggseg` | [ggsegverse/ggseg](https://github.com/ggsegverse/ggseg) | 2D brain atlas visualization via ggplot2 |
| `ggseg3d` | [ggsegverse/ggseg3d](https://github.com/ggsegverse/ggseg3d) | 3D brain atlas visualization via Three.js/htmlwidgets |
| `ggseg.meshes` | [ggsegverse/ggseg.meshes](https://github.com/ggsegverse/ggseg.meshes) | Additional brain surface meshes (pial, white, sphere, smoothwm, orig, SUIT flatmap) |

These packages form the visualization core of the ggsegverse ecosystem. Atlas creation tools (`ggseg.extra`) and the meta-package (`ggsegverse`) are still in development and will be submitted separately.