### PR TITLE
Healthcare: add californiaalw

### DIFF
--- a/packages/californiaalw
+++ b/packages/californiaalw
@@ -1,0 +1,1 @@
+https://github.com/asafichaki/californiaalw


### PR DESCRIPTION
Adds [californiaalw](https://github.com/asafichaki/californiaalw), an MIT-licensed R data package for the California Assisted Living Waiver provider list and county aggregates. The bundled prepared data are CC BY 4.0, the upstream source is the California Department of Health Care Services, and release v0.1.0 is public.\n\nThe package passed R CMD check locally with 0 errors and 0 warnings; its public GitHub Actions check is also running.