### PR TITLE
Deregister adbcbigquery and adbcsnowflake

### DIFF
--- a/packages/adbcbigquery
+++ b/packages/adbcbigquery
@@ -1,6 +1,5 @@
-{
-  "package": "adbcbigquery",
-  "url": "https://github.com/apache/arrow-adbc",
-  "subdir": "r/adbcbigquery",
-  "branch": "*release"
-}
+This package was deregistered from R-multiverse on 2026-07-30.
+The r/adbcbigquery subdirectory was removed from https://github.com/apache/arrow-adbc upstream.
+It is present in release https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-23 but not https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-24.
+The listing therefore no longer points to an existing source code repository.
+This file is retained as a placeholder to reserve the package name.

--- a/packages/adbcsnowflake
+++ b/packages/adbcsnowflake
@@ -1,6 +1,5 @@
-{
-  "package": "adbcsnowflake",
-  "url": "https://github.com/apache/arrow-adbc",
-  "subdir": "r/adbcsnowflake",
-  "branch": "*release"
-}
+This package was deregistered from R-multiverse on 2026-07-30.
+The r/adbcbigquery subdirectory was removed from https://github.com/apache/arrow-adbc upstream.
+It is present in release https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-23 but not https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-24.
+The listing therefore no longer points to an existing source code repository.
+This file is retained as a placeholder to reserve the package name.

--- a/packages/adbcsnowflake
+++ b/packages/adbcsnowflake
@@ -1,5 +1,5 @@
 This package was deregistered from R-multiverse on 2026-07-30.
-The r/adbcbigquery subdirectory was removed from https://github.com/apache/arrow-adbc upstream.
+The r/snowflake subdirectory was removed from https://github.com/apache/arrow-adbc upstream.
 It is present in release https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-23 but not https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-24.
 The listing therefore no longer points to an existing source code repository.
 This file is retained as a placeholder to reserve the package name.


### PR DESCRIPTION
The r/adbcbigquery and r/adbcsnowflake subdirectories were removed from https://github.com/apache/arrow-adbc upstream.
They are present in release https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-23 but not https://github.com/apache/arrow-adbc/releases/tag/apache-arrow-adbc-24.
The listings therefore no longer point to existing source code repositories.
The listing files are retained as placeholders to reserve the package name.
